### PR TITLE
Fixes #4501, Xcode 8.1 compatibility

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -26,7 +26,7 @@ public class DependencyBank {
 	//Temporary snapshot version, we need a more dynamic solution for pointing to the latest nightly
 	static String libgdxNightlyVersion = "1.9.5-SNAPSHOT";
 	static String roboVMVersion = "2.2.0";
-	static String moeVersion = "1.2.3";
+	static String moeVersion = "1.2.5";
 	static String buildToolsVersion = "23.0.1";
 	static String androidAPILevel = "20";
 	static String gwtVersion = "2.8.0";


### PR DESCRIPTION
Fixes Xcode 8.1 compatibility issues in project generated with `gdx-setup` (issue #4501) by changing the `moe-gradle` version from 1.2.3 to 1.2.5